### PR TITLE
docs: Add Packages section to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,105 @@
 This is a monorepo for the following projects:
 
 🔨 Working 🔨
+
+## Packages
+
+### @kreisler/anime-api
+Description: Un forma diferente de hacer peticiones a una API
+README Summary:
+# Create API
+
+Create API is a simple package to create API requests with ease.
+[@kreisler/createapi](https://www.npmjs.com/package/@kreisler/createapi)
+[View package](./packages/anime-api)
+
+### @kreisler/bot-tl-ts
+Description: A simple Telegram bot using TypeScript
+README Summary: This package does not have a README.md or it is empty.
+[View package](./packages/bot-tl-ts)
+
+### @kreisler/bot-wa-ts
+Description: A simple WhatsApp bot using TypeScript
+README Summary: This package does not have a README.md or it is empty.
+[View package](./packages/bot-wa-ts)
+
+### @kreisler/createapi
+Description: Un forma diferente de hacer peticiones a una API
+README Summary:
+# Create API
+
+Create API is a simple package to create API requests with ease.
+[@kreisler/createapi](https://www.npmjs.com/package/@kreisler/createapi)
+[View package](./packages/createapi)
+
+### @kreisler/debounce
+Description: Debounce function for javascript
+README Summary:
+# Debounce
+
+A simple utility to debounce a function.
+[View package](./packages/debounce)
+
+### @kreisler/dirname-for-module
+Description: dirname for module (import/export)
+README Summary:
+# dirname-for-module
+
+This package only works in esm module, config `type: module` in package.json
+[View package](./packages/dirname-for-module)
+
+### @kreisler/exec-promise
+Description: Wrapper for child_process.exec that returns a promise
+README Summary:
+# Exec Promise
+
+A simple Exec Promise package that allows you to execute a command in a promise.
+[View package](./packages/exec-promise)
+
+### @kreisler/js-cron
+Description: Wrapper for node-cron
+README Summary:
+# JsCron - Node.js Cron Task Manager ⏰🚀
+
+A powerful and flexible class for managing scheduled tasks using `node-cron` in Node.js with TypeScript support.
+[View package](./packages/js-cron)
+
+### @kreisler/js-helpers
+Description: Is a Javascript library for dealing with code repetition
+README Summary:
+# Colelction of JavaScript helpers
+
+@kreisler/js-helpers is a Javascript library for dealing with code repetition
+[View package](./packages/js-helpers)
+
+### @kreisler/pkg
+Description: Template for creating a new package
+README Summary:
+# JS Google Translate Free + Typescript 🚀
+
+Simple JS library for talking to Google's Translate API for free.
+[View package](./packages/pkg)
+
+### my-project
+Description: No description provided.
+README Summary:
+# Proyecto generado por Klei CLI.
+[View package](./packages/plugins)
+
+### @kreisler/pkgs
+Description: No description provided.
+README Summary: This package does not have a README.md or it is empty.
+[View package](./packages/template)
+
+### test
+Description: No description provided.
+README Summary: This package does not have a README.md.
+[View package](./packages/test)
+
+### @kreisler/try-catch
+Description: Functional try-catch wrapper
+README Summary:
+# Try Catch
+
+A simple try-catch wrapper for functions and async functions.
+[View package](./packages/try-catch)


### PR DESCRIPTION
This commit introduces a new "Packages" section to the main README.md file. This section provides a brief overview of each package within the monorepo, including:

- The package name.
- Its description as defined in its package.json.
- A short summary from the package's own README.md, if available.
- A direct link to the package's directory for more detailed information.

This aims to improve the discoverability and understanding of the different components within this repository.